### PR TITLE
Support Debian 8 (systemd-based) and some misc fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Module has been tested on:
 
 * Puppet 3.6
 * OS:
- * Debian 6,7
+ * Debian 6,7,8
  * RHEL/CentOS 6,7
 
 Required modules:
@@ -36,6 +36,7 @@ class { 'serial_console':
   tty                    => '...',       # text console name
   ttys                   => '...',       # serial device name without path, e.g. ttyS0
   speed                  => ...,         # serial port speed, e.g. 115200
+  term_type              => ...,         # serial terminal type, e.g. vt100
   runlevels              => '...',       # run levels for login over serial
   bootloader_timeout     => '...'        # bootloader timeout
   logout_timeout         => '...',       # interactive session timeout

--- a/manifests/autologout.pp
+++ b/manifests/autologout.pp
@@ -2,13 +2,13 @@ class serial_console::autologout (
   $logout_timeout
 ) {
   if is_numeric($logout_timeout) and $logout_timeout>0 {
-    $_ensure=file
+    $ensure=file
   } else {
-    $_ensure=absent
+    $ensure=absent
   }
 
   file { '/etc/profile.d/ttyS_autologout.sh':
-    ensure  => $_ensure,
+    ensure  => $ensure,
     content => template('serial_console/ttyS_autologout.sh.erb'),
   }
 }

--- a/manifests/getty/inittab.pp
+++ b/manifests/getty/inittab.pp
@@ -2,6 +2,7 @@ class serial_console::getty::inittab (
   $ttys,
   $ttys_id,
   $speed,
+  $term_type,
   $runlevels
 ) {
   augeas { "inittab-agetty-${ttys}":
@@ -12,7 +13,7 @@ class serial_console::getty::inittab (
     changes => [
       "set runlevels ${runlevels}",
       'set action respawn',
-      "set process '/sbin/getty -8L ${speed} ${ttys} vt100'"
+      "set process '/sbin/getty -8L ${speed} ${ttys} ${term_type}'"
     ]
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,7 +34,7 @@ class serial_console (
   $ttys_id = regsubst($ttys,'^ttyS(\d+)$','\1')
   validate_re($ttys_id, '^\d+$')
 
-  if ! ($ttys in $serial_console::params::_serialports) {
+  if ! ($ttys in $serial_console::params::l_serialports) {
     err("Invalid serial port '${ttys}'")
 
   } elsif $enable {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@ class serial_console (
   $tty                    = $serial_console::params::tty,
   $ttys                   = $serial_console::params::ttys,
   $speed                  = $serial_console::params::speed,
+  $term_type              = $serial_console::params::term_type,
   $runlevels              = $serial_console::params::runlevels,
   $bootloader_timeout     = $serial_console::params::bootloader_timeout,
   $logout_timeout         = $serial_console::params::logout_timeout,
@@ -41,9 +42,9 @@ class serial_console (
     $class_kernel = $serial_console::params::class_kernel
     if $enable_kernel and $class_kernel {
       class { "serial_console::kernel::${class_kernel}":
-        tty   => $tty,
-        ttys  => $ttys,
-        speed => $speed,
+        tty       => $tty,
+        ttys      => $ttys,
+        speed     => $speed,
       }
     }
 
@@ -65,6 +66,7 @@ class serial_console (
         ttys_id   => $ttys_id,
         speed     => $speed,
         runlevels => $runlevels,
+        term_type => $term_type,
       }
     }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,10 +16,10 @@ class serial_console (
 
   validate_bool($enable, $enable_kernel, $enable_bootloader, $enable_login)
   validate_string($ttys, $runlevels)
-  validate_re($speed, '^\d+$')
-  validate_re($runlevels, '^\d+$')
-  validate_re($bootloader_timeout, '^\d+$')
-  validate_re($logout_timeout, '^\d+$')
+  validate_re("${speed}", '^\d+$')
+  validate_re("${runlevels}", '^\d+$')
+  validate_re("${bootloader_timeout}", '^\d+$')
+  validate_re("${logout_timeout}", '^\d+$')
 
   if $cmd_refresh_init {
     validate_absolute_path($cmd_refresh_init)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -54,6 +54,14 @@ ${::operatingsystem} ${::operatingsystemmajrelease}")
           $cmd_refresh_bootloader = '/usr/sbin/update-grub'
         }
 
+        8: {
+          $class_kernel = 'grub2'
+          $class_bootloader = 'grub2'
+          $class_getty = undef
+          $cmd_refresh_init = undef
+          $cmd_refresh_bootloader = '/usr/sbin/update-grub'
+        }
+
         default: {
           fail("Unsupported OS version: \
 ${::operatingsystem} ${::operatingsystemmajrelease}")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class serial_console::params {
     $ttys = 'ttyS0'
   }
 
+  $term_type = 'vt100'
   $tty = 'tty0'
   $speed = 115200
   $runlevels = '2345'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,9 +5,9 @@ class serial_console::params {
   $enable_login = true
 
   # choose last available port
-  $_serialports = reverse(split($::serialports, ','))
-  if $_serialports[0] {
-    $ttys = $_serialports[0]
+  $l_serialports = reverse(split($::serialports, ','))
+  if $l_serialports[0] {
+    $ttys = $l_serialports[0]
   } else {
     $ttys = 'ttyS0'
   }


### PR DESCRIPTION
Hi,

I have a few fixes here that allow for Debian 8 support (not that difficult, just don't try to update /etc/inittab).

As I was going along, I noticed there were variables with a leading underscore. Puppet 4 no longer allows those, so I figured I'd save some work later on and changed them as well.

While I was testing the module using Hiera data, I also noticed that the `speed`, `runlevels`, `bootloader_timeout` and `logout_timeout` parameters could not be specified as numbers (at least under Puppet 3.7), so I changed the validation to first coerce them into strings (`"${speed}"`) and then run the validation on them.

Finally, I added the `term_type` parameter, because I prefer `vt102` over `vt100` :-)

Hope you find this useful.
