### PR TITLE
Centos 6.x upstart/agetty implementation

### DIFF
--- a/manifests/getty/upstart.pp
+++ b/manifests/getty/upstart.pp
@@ -1,0 +1,19 @@
+class serial_console::getty::upstart (
+  $ttys,
+  $ttys_id,
+  $speed,
+  $term_type,
+  $runlevels
+) {
+  file { "/etc/init/$ttys.conf":
+    ensure => file,
+    content => template('serial_console/ttyS_agetty.conf.erb'),
+  }
+  augeas { "securetty_$ttys":
+    context => "/files/etc/securetty",
+    changes => [ "ins 0 before /files/etc/securetty/1",
+                 "set /files/etc/securetty/0 $ttys",],
+    onlyif => "match *[.='$ttys'] size == 0",
+  }
+
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,11 +21,19 @@ class serial_console::params {
   case $::operatingsystem {
     redhat,centos,scientific,oraclelinux: {
       case $::operatingsystemmajrelease {
-        5,6: {
+        5: {
           $class_kernel = 'grubby'
           $class_bootloader = 'grub1'
           $class_getty = undef
           $cmd_refresh_init = undef
+          $cmd_refresh_bootloader = undef
+        }
+
+        6: {
+          $class_kernel = 'grubby'
+          $class_bootloader = 'grub1'
+          $class_getty = 'upstart'
+          $cmd_refresh_init = "/sbin/start $ttys"
           $cmd_refresh_bootloader = undef
         }
 

--- a/templates/ttyS_agetty.conf.erb
+++ b/templates/ttyS_agetty.conf.erb
@@ -1,0 +1,7 @@
+# This file is managed by Puppet!
+# <%= @ttys %>
+stop on runlevel [S016]
+start on runlevel [235]
+
+respawn
+exec agetty -8 -L -w /dev/<%= @ttys %> <%= @speed %> <%= @term_type %>


### PR DESCRIPTION
Following an excellent [blog entry](http://blog.chrysocome.net/2013/05/proliant-virtual-serial-port.html) by John Newbigin, I've added the necessary upstart class to create the ttySX.conf entries required for EL6.x distributions to provide a serial console
