### PR TITLE
Fix case statement for puppet 4

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,7 @@ class serial_console::params {
   $logout_timeout = 0
 
   case $::operatingsystem {
-    'redhat','centos','scientific','oraclelinux': {
+    'RedHat','CentOS','scientific','oraclelinux': {
       case $::operatingsystemmajrelease {
         '5','6': {
           $class_kernel = 'grubby'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,9 +19,9 @@ class serial_console::params {
   $logout_timeout = 0
 
   case $::operatingsystem {
-    redhat,centos,scientific,oraclelinux: {
+    'redhat','centos','scientific','oraclelinux': {
       case $::operatingsystemmajrelease {
-        5,6: {
+        '5','6': {
           $class_kernel = 'grubby'
           $class_bootloader = 'grub1'
           $class_getty = undef
@@ -29,7 +29,7 @@ class serial_console::params {
           $cmd_refresh_bootloader = undef
         }
 
-        7: {
+        '7': {
           $class_kernel = 'grub2'
           $class_bootloader = 'grub2'
           $class_getty = undef
@@ -44,9 +44,9 @@ ${::operatingsystem} ${::operatingsystemmajrelease}")
       }
     }
 
-    debian: {
+    'debian:' {
       case $::operatingsystemmajrelease {
-        6,7: {
+        '6','7': {
           $class_kernel = 'grub2'
           $class_bootloader = 'grub2'
           $class_getty = 'inittab'
@@ -54,7 +54,7 @@ ${::operatingsystem} ${::operatingsystemmajrelease}")
           $cmd_refresh_bootloader = '/usr/sbin/update-grub'
         }
 
-        8: {
+        '8': {
           $class_kernel = 'grub2'
           $class_bootloader = 'grub2'
           $class_getty = undef


### PR DESCRIPTION
Hello, I've just come across your module (great work!) and am incorporating into my environment which is using Puppet 4.5.1 and facter 3.2.0 and I had compile errors like the following:

Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Error while evaluating a Function Call, Unsupported OS version: RedHat 6 at /etc/puppetlabs/code/environments/grub/mod
ules/serial_console/manifests/params.pp:49:11

I believe that facter in Puppet 4 is returning the osfamily fact differently to before perhaps using CamelCase, so I've updated CentOS and RedHat to reflect this (I only have systems with these two OS to test on). I also added quotes around the case statement values as that caused another compile error for me.
