### PR TITLE
Replace File.exists? method with File.exist?

### DIFF
--- a/lib/facter/grub1conf.rb
+++ b/lib/facter/grub1conf.rb
@@ -12,7 +12,7 @@ Facter.add("grub1conf") do
   setcode do
     value = nil
     ['/boot/grub/menu.lst','/etc/grub.conf'].each do |fn|
-      if File.exists?(fn)
+      if File.exist?(fn)
         value = fn
         break
       end

--- a/lib/facter/serialports.rb
+++ b/lib/facter/serialports.rb
@@ -17,7 +17,7 @@ Facter.add("serialports") do
     ports = []
 
     fn = '/proc/tty/driver/serial'
-    if File.exists?(fn)
+    if File.exist?(fn)
       File.open(fn).each do |line|
         # serinfo:1.0 driver revision:
         # 0: uart:16550A port:000003F8 irq:4 tx:0 rx:0
@@ -40,7 +40,7 @@ Facter.add("usbserialports") do
     ports = []
 
     fn = '/proc/tty/driver/usbserial'
-    if File.exists?(fn)
+    if File.exist?(fn)
       File.open(fn).each do |line|
         # usbserinfo:1.0 driver:2.0
         # 0: module:usb_serial_simple name:"suunto" vendor:0fcf product:1008 num_ports:1 port:0 path:usb-0000:00:1a.0-1.1.1.2


### PR DESCRIPTION
This PR replaces the File.exists? method with File.exist? for compatibility with Ruby 3.2 and Puppet 8.

File.exists? was deprecated in Ruby 2.2.